### PR TITLE
chore: change test coverage tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+coverage
 dist
 .vscode
 package-lock.json

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,7 @@ const config: InitialOptionsTsJest = {
       // ts-jest configuration goes here
     },
   },
-  testRegex: "test/.*.\\.(ts)$"
+  testRegex: "test/.*.\\.(ts)$",
+  "coverageProvider": "v8",
 }
 export default config

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "nodemon",
     "lint": "eslint . --ext .ts",
-    "test": "jest test/",
+    "test": "jest --config ./jest.config.ts",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
     "build": "tsc --project tsconfig.json"
   },


### PR DESCRIPTION
Default test coverage tool (istanbul) in jest is throwing error. Changed default test coverage tool
to c8.

closes #3